### PR TITLE
change FOI subject

### DIFF
--- a/tna-forms-processor.php
+++ b/tna-forms-processor.php
@@ -317,7 +317,12 @@ class Form_Processor {
 		if ( is_email( $email ) ) {
 
 			// Email Subject
-			$email_subject = $subject . ' ' . $ref_number;
+
+			if (strpos($subject, 'FOI DIRECT') === false) {
+				$email_subject = $subject . ' ' . $ref_number;
+			} else {
+				$email_subject = $subject;
+			}
 
 			// Email message
 			$email_message = $content;


### PR DESCRIPTION
FOI don't want a reference number in their email subjects - so this is another tna-forms hack to not add the reference number if the subject contains FOI DIRECT - if you think there's a neater way please say! 

